### PR TITLE
feat: derive Clone trait for ScheduledThreadPool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ impl SharedPool {
 ///
 /// When the pool drops, all pending scheduled executions will be run, but
 /// periodic actions will not be rescheduled after that.
+#[derive(Clone)]
 pub struct ScheduledThreadPool {
     shared: Arc<SharedPool>,
 }


### PR DESCRIPTION
Convenient to share a thread pool in multiple database connection pools in r2d2.