### PR TITLE
Derive Debug on JobHandle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use crate::thunk::Thunk;
 mod thunk;
 
 /// A handle to a scheduled job.
+#[derive(Debug)]
 pub struct JobHandle(Arc<AtomicBool>);
 
 impl JobHandle {


### PR DESCRIPTION
As the title would suggest. Ran into this today when I had a struct holding a `JobHandle` and realized it didn't `impl Debug`, any objections to it?