### PR TITLE
Add methods for waiting and polling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,6 +736,25 @@ mod test {
     }
 
     #[test]
+    fn wait_on_canceled_job() {
+        let pool = ScheduledThreadPool::new(TEST_TASKS);
+        let start_time = SystemTime::now();
+
+        let handle = pool.execute_at_fixed_rate(
+            Duration::from_millis(500),
+            Duration::from_millis(500),
+            || {
+                return;
+            }
+        );
+        handle.cancel();
+        handle.wait_for(3);
+        handle.wait();
+        let time_elapsed = start_time.elapsed().unwrap().as_millis();
+        assert!(time_elapsed < 100);
+    }
+
+    #[test]
     fn poll() {
         let pool = ScheduledThreadPool::new(TEST_TASKS);
         let handle = pool.execute_after(


### PR DESCRIPTION
I was about to use this crate, but the JobHandle type didn't have the feature I wanted (a `wait` function). Given the popularity of this crate I imagine other people have probably thought the same, so I thought I might as well implement it and see what you think.