### PR TITLE
Add new types of behavior for when the `ScheduledThreadPool` is dropped

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! While a normal thread pool is only able to execute actions as soon as
 //! possible, a scheduled thread pool can execute actions after a specific
-//! delay, or excecute actions periodically.
+//! delay, or execute actions periodically.
 #![warn(missing_docs)]
 
 use parking_lot::{Condvar, Mutex};


### PR DESCRIPTION
Add `ScheduledThreadPool::with_name_and_drop_behavior` method that creates a
`ScheduledThreadPool` with the provided name, number of threads, and the desired
behavior in relation to pending scheduled executions when the pool is dropped.

This on drop behavior is specified using the new `OnPoolDropBehavior` enum.

The existing behavior (and the default) is specified as
`CompletePendingScheduled`. This means that all pending scheduled executions
will be run, but periodic actions will not be rescheduled once these have
completed.

The other option is `DiscardPendingScheduled`. As the name suggests, this
behavior means that any pending scheduled executions will be discarded (not
run).

---

Introduce a `ScheduledThreadPoolBuilder` type that allows using a builder
pattern to configure a new pool.

This builder pattern must be used if you wish to control the behavior of the
pool when it's dropped (via the builder's `on_drop_behavior` method).

---

Fix a docs typo

---

~For what it's worth, I don't love the new `with_name_and_drop_behavior` method. I was tempted to add a builder pattern, of sorts, but didn't want to bloat the scope of this PR before getting feedback on this smaller change. As things stand the public API hasn't changed other than with the addition of `with_name_and_drop_behavior`.~ Updated to add a `ScheduledThreadPoolBuilder`

For more context, the motivation for taking a look into this is https://github.com/sfackler/r2d2/issues/99. The [`reap_connections` scheduled executions](https://github.com/sfackler/r2d2/blob/1178d1805dda0ec08f9cec626a67575691c0ce8f/src/lib.rs#L381-L385) there mean that the threads are kept alive for 30s after the pool has been dropped (in the worst case). This is unfortunate especially seeing as the `SharedPool` in r2d2 would have already been long dropped by the time the scheduled execution ended up being run and so the `None` path of this code would get hit: https://github.com/sfackler/r2d2/blob/1178d1805dda0ec08f9cec626a67575691c0ce8f/src/lib.rs#L288-L291.

With the additions in this PR it would be possible to update the [creation of the `ScheduledThreadPool`](https://github.com/sfackler/r2d2/blob/1178d1805dda0ec08f9cec626a67575691c0ce8f/src/config.rs#L258) to use one of these new `OnDropBehavior`s, or at least allow users to specify their own `ScheduledThreadPool` that uses one of these new `OnDropBehaviour`s via [the `thread_pool` method on the builder](https://github.com/sfackler/r2d2/blob/1178d1805dda0ec08f9cec626a67575691c0ce8f/src/config.rs#L107-L114).